### PR TITLE
Update the rockets to collect the first images

### DIFF
--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -42,7 +42,7 @@ const rocketSlice = createSlice({
           id: key[1].id,
           name: key[1].rocket_name,
           description: key[1].description,
-          flickr_images: key[1].flickr_images[1],
+          flickr_images: key[1].flickr_images[0],
           reserved: false,
         });
       });


### PR DESCRIPTION
## Update the rockets to collect the first images

- Retrieve only the first image from the flickr_images array in the API.
- Fix Linter errors.